### PR TITLE
cli: skip vendor dirs during scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Status: v1 pipeline works. `txt` / `md` / `docx` / `hwpx` / binary `hwp` / `pptx
 
 ```bash
 dupey scan ./docs --json          # the public contract
+dupey scan ./docs --exclude-dir 임시 --exclude-dir 백업
 dupey fingerprint proposal.docx   # canonical text hash + internal metadata
 dupey compare 최종.docx 찐최종.docx
 ```
+
+`scan` does not descend into vendor/VCS/tooling folders (`node_modules`, `.git`, `target`, `dist`, `build`, …). Add more folder **names** with repeatable `--exclude-dir`.
+
 
 ```jsonc
 // scan DIR --json

--- a/crates/dupey-cli/src/main.rs
+++ b/crates/dupey-cli/src/main.rs
@@ -1,10 +1,12 @@
+mod skip;
+
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use dupey_core::{
-    cluster, containment, exact_hash_hex, extract, near_sig, rank, CanonicalText,
-    Format, MemberSignals, ScannedDoc, DEFAULT_NEAR_THRESHOLD,
+    cluster, containment, exact_hash_hex, extract, near_sig, rank, CanonicalText, Format,
+    MemberSignals, ScannedDoc, DEFAULT_NEAR_THRESHOLD,
 };
 use serde::Serialize;
 
@@ -34,6 +36,10 @@ enum Command {
         /// Family threshold for near/contains (Jaccard estimate)
         #[arg(long, default_value_t = DEFAULT_NEAR_THRESHOLD)]
         threshold: f64,
+        /// Extra directory names to skip (folder name, not a path). Repeatable.
+        /// Merged with builtins: node_modules, .git, target, dist, build, ...
+        #[arg(long = "exclude-dir", value_name = "NAME", action = clap::ArgAction::Append)]
+        exclude_dir: Vec<String>,
     },
 }
 
@@ -45,7 +51,8 @@ fn main() -> Result<()> {
             dir,
             json,
             threshold,
-        } => scan(&dir, json, threshold),
+            exclude_dir,
+        } => scan(&dir, json, threshold, &exclude_dir),
     }
 }
 
@@ -132,16 +139,20 @@ struct ScanOut {
     errors: Vec<ErrorEntry>,
 }
 
-fn scan(dir: &Path, json: bool, threshold: f64) -> Result<()> {
+fn scan(dir: &Path, json: bool, threshold: f64, extra_exclude: &[String]) -> Result<()> {
     let t0 = std::time::Instant::now();
     let mut files: Vec<FileEntry> = Vec::new();
     let mut docs: Vec<ScannedDoc> = Vec::new();
     let mut metas: Vec<(CanonicalText, Option<jiff::Timestamp>)> = Vec::new();
     let mut errors: Vec<ErrorEntry> = Vec::new();
 
+    let skip = skip::skip_set(extra_exclude);
     let mut paths: Vec<PathBuf> = Vec::new();
     for entry in walkdir::WalkDir::new(dir)
         .into_iter()
+        .filter_entry(|e| {
+            !skip::should_skip_dir(e.file_name(), e.file_type().is_dir(), e.depth(), &skip)
+        })
         .filter_map(|e| e.ok())
     {
         if entry.file_type().is_file() && Format::from_path(entry.path()).is_some() {
@@ -203,11 +214,8 @@ fn scan(dir: &Path, json: bool, threshold: f64) -> Result<()> {
     }
     // Shingle sets are already computed in `docs`; reuse them instead of
     // re-shingling per member pair (that made rank O(m^2) re-extraction).
-    let doc_index: std::collections::HashMap<&PathBuf, usize> = docs
-        .iter()
-        .enumerate()
-        .map(|(i, d)| (&d.path, i))
-        .collect();
+    let doc_index: std::collections::HashMap<&PathBuf, usize> =
+        docs.iter().enumerate().map(|(i, d)| (&d.path, i)).collect();
     let mut family_out = Vec::new();
     for fam in &families {
         let signals: Vec<MemberSignals> = fam
@@ -228,12 +236,12 @@ fn scan(dir: &Path, json: bool, threshold: f64) -> Result<()> {
                     .map(|&oi| &docs[oi].shingles)
                     .collect();
                 let contains_others = !others.is_empty()
-                    && others.iter().all(|os| {
-                        !os.is_empty() && containment(my_shingles, os) >= threshold
-                    });
-                let contained_by_other = others.iter().any(|os| {
-                    !my_shingles.is_empty() && containment(os, my_shingles) >= threshold
-                });
+                    && others
+                        .iter()
+                        .all(|os| !os.is_empty() && containment(my_shingles, os) >= threshold);
+                let contained_by_other = others
+                    .iter()
+                    .any(|os| !my_shingles.is_empty() && containment(os, my_shingles) >= threshold);
                 MemberSignals {
                     path: m.path.clone(),
                     internal_modified: canon.meta.modified,

--- a/crates/dupey-cli/src/skip.rs
+++ b/crates/dupey-cli/src/skip.rs
@@ -1,0 +1,124 @@
+//! Directory names `scan` does not descend into.
+//!
+//! Matching is on a single folder name (case-insensitive), never a path
+//! substring. The walk root itself is never skipped, so `dupey scan
+//! node_modules` still reads that folder's own files.
+
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::Path;
+
+/// Built-in vendor / VCS / tooling directories. Extra names come from
+/// `--exclude-dir` and are merged into the same set.
+pub const DEFAULT_SKIP_DIR_NAMES: &[&str] = &[
+    ".git",
+    ".svn",
+    ".hg",
+    ".venv",
+    "venv",
+    "node_modules",
+    "bower_components",
+    "target",
+    "dist",
+    "build",
+    "__pycache__",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".idea",
+    ".vscode",
+    ".next",
+    ".nuxt",
+    ".cache",
+    ".gradle",
+    "Pods",
+];
+
+pub fn skip_set(extra: &[String]) -> HashSet<String> {
+    let mut set: HashSet<String> = DEFAULT_SKIP_DIR_NAMES
+        .iter()
+        .map(|s| s.to_lowercase())
+        .collect();
+    for name in extra {
+        if let Some(n) = normalize_dir_name(name) {
+            set.insert(n);
+        }
+    }
+    set
+}
+
+/// Last path component, lowercased. `./임시/` and `임시` are the same name.
+fn normalize_dir_name(name: &str) -> Option<String> {
+    let trimmed = name.trim().trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
+        return None;
+    }
+    let component = Path::new(trimmed)
+        .file_name()
+        .unwrap_or_else(|| OsStr::new(trimmed));
+    let lower = component.to_string_lossy().to_lowercase();
+    if lower.is_empty() {
+        None
+    } else {
+        Some(lower)
+    }
+}
+
+/// Skip this directory entry (and therefore do not walk its children).
+/// Files are never skipped here; `Format::from_path` still decides extract.
+pub fn should_skip_dir(
+    file_name: &OsStr,
+    is_dir: bool,
+    depth: usize,
+    skip: &HashSet<String>,
+) -> bool {
+    if depth == 0 || !is_dir {
+        return false;
+    }
+    skip.contains(&file_name.to_string_lossy().to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    fn set(extra: &[&str]) -> HashSet<String> {
+        skip_set(&extra.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+    }
+
+    fn skip(name: &str, is_dir: bool, depth: usize, extra: &[&str]) -> bool {
+        should_skip_dir(&OsString::from(name), is_dir, depth, &set(extra))
+    }
+
+    #[test]
+    fn defaults_skip_vendor_and_vcs() {
+        assert!(skip("node_modules", true, 1, &[]));
+        assert!(skip("Node_Modules", true, 2, &[]));
+        assert!(skip(".git", true, 1, &[]));
+        assert!(skip("target", true, 1, &[]));
+        assert!(!skip("docs", true, 1, &[]));
+        assert!(!skip("my_build_notes", true, 1, &[]));
+    }
+
+    #[test]
+    fn extra_names_merge_case_insensitively() {
+        assert!(skip("임시", true, 1, &["임시"]));
+        assert!(skip("백업", true, 1, &["./백업/"]));
+        assert!(!skip("임시", true, 1, &[]));
+    }
+
+    #[test]
+    fn root_and_files_are_not_skipped() {
+        assert!(!skip("node_modules", true, 0, &[]));
+        assert!(!skip("node_modules", false, 1, &[]));
+        assert!(!skip("LICENSE.md", false, 2, &[]));
+    }
+
+    #[test]
+    fn empty_or_dot_extra_names_are_ignored() {
+        let s = set(&["", "  ", ".", ".."]);
+        assert_eq!(s.len(), DEFAULT_SKIP_DIR_NAMES.len());
+    }
+}

--- a/crates/dupey-cli/tests/cli.rs
+++ b/crates/dupey-cli/tests/cli.rs
@@ -13,16 +13,25 @@ fn fixture_dir(name: &str, files: &[(&str, &str)]) -> PathBuf {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     for (fname, body) in files {
-        std::fs::write(dir.join(fname), body).unwrap();
+        let path = dir.join(fname);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, body).unwrap();
     }
     dir
 }
 
 fn scan_json(dir: &Path) -> serde_json::Value {
+    scan_json_with(dir, &[])
+}
+
+fn scan_json_with(dir: &Path, extra: &[&str]) -> serde_json::Value {
     let out = dupey()
-        .args(["scan"])
+        .arg("scan")
         .arg(dir)
         .arg("--json")
+        .args(extra)
         .output()
         .unwrap();
     assert!(
@@ -33,7 +42,17 @@ fn scan_json(dir: &Path) -> serde_json::Value {
     serde_json::from_slice(&out.stdout).unwrap()
 }
 
-const PROPOSAL: &str = "프로젝트 제안서\n\n1. 배경\n본 제안은 2026년 하반기 사무 자동화 도입을 위한 것이다. \
+fn scanned_paths(v: &serde_json::Value) -> Vec<String> {
+    v["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["path"].as_str().unwrap().replace('\\', "/"))
+        .collect()
+}
+
+const PROPOSAL: &str =
+    "프로젝트 제안서\n\n1. 배경\n본 제안은 2026년 하반기 사무 자동화 도입을 위한 것이다. \
      현재 팀은 문서가 폴더에 흩어져 있고 최신본을 찾기 어렵다.\n\n2. 범위\n문서 수집, \
      중복 정리, 검색, 권한은 1단계 범위에 포함하지 않는다.\n\n3. 일정\n킥오프는 9월 1일, \
      파일럿은 10월 말까지 진행한다.\n\n4. 예산\n예상 비용은 3,200만 원이다.\n";
@@ -101,10 +120,7 @@ fn scan_finds_near_family_and_picks_final() {
 fn scan_exact_duplicate_group() {
     let dir = fixture_dir(
         "exact",
-        &[
-            ("보고서.txt", PROPOSAL),
-            ("보고서 사본.txt", PROPOSAL),
-        ],
+        &[("보고서.txt", PROPOSAL), ("보고서 사본.txt", PROPOSAL)],
     );
     let v = scan_json(&dir);
     let families = v["families"].as_array().unwrap();
@@ -116,11 +132,18 @@ fn scan_exact_duplicate_group() {
 #[test]
 fn fingerprint_and_compare_still_work() {
     let dir = fixture_dir("basic", &[("a.txt", PROPOSAL)]);
-    let out = dupey().args(["fingerprint"]).arg(dir.join("a.txt")).output().unwrap();
+    let out = dupey()
+        .args(["fingerprint"])
+        .arg(dir.join("a.txt"))
+        .output()
+        .unwrap();
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("exact\t"), "{stdout}");
-    assert!(stdout.contains("modified\t"), "fingerprint shows meta: {stdout}");
+    assert!(
+        stdout.contains("modified\t"),
+        "fingerprint shows meta: {stdout}"
+    );
 
     let out = dupey()
         .args(["compare"])
@@ -131,4 +154,72 @@ fn fingerprint_and_compare_still_work() {
     assert!(out.status.success());
     assert!(String::from_utf8_lossy(&out.stdout).contains("exact_equal\ttrue"));
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_skips_default_vendor_dirs() {
+    let dir = fixture_dir(
+        "skip-vendor",
+        &[
+            ("제안서.txt", PROPOSAL),
+            ("docs/메모.txt", "내일 회의실 예약하기\n"),
+            ("node_modules/pkg/LICENSE.md", "MIT License\n"),
+            (".git/README.md", "git readme\n"),
+            ("build/junk.txt", "build artifact\n"),
+            ("my_build_notes/keep.txt", "not a vendor dir\n"),
+        ],
+    );
+    let paths = scanned_paths(&scan_json(&dir));
+    assert!(paths.iter().any(|p| p.ends_with("제안서.txt")), "{paths:?}");
+    assert!(paths.iter().any(|p| p.ends_with("메모.txt")), "{paths:?}");
+    assert!(
+        paths.iter().any(|p| p.ends_with("keep.txt")),
+        "substring build must not skip my_build_notes: {paths:?}"
+    );
+    assert!(
+        paths.iter().all(|p| !p.contains("/node_modules/")),
+        "{paths:?}"
+    );
+    assert!(paths.iter().all(|p| !p.contains("/.git/")), "{paths:?}");
+    assert!(paths.iter().all(|p| !p.contains("/build/")), "{paths:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_exclude_dir_adds_names() {
+    let dir = fixture_dir(
+        "skip-extra",
+        &[
+            ("keep.txt", PROPOSAL),
+            ("임시/버림.txt", PROPOSAL),
+            ("백업/old.txt", PROPOSAL),
+        ],
+    );
+    let paths = scanned_paths(&scan_json_with(
+        &dir,
+        &["--exclude-dir", "임시", "--exclude-dir", "./백업/"],
+    ));
+    assert_eq!(paths.len(), 1, "{paths:?}");
+    assert!(paths[0].ends_with("keep.txt"), "{paths:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_root_named_like_vendor_is_still_read() {
+    let parent = std::env::temp_dir().join("dupey-cli-root-skip");
+    let _ = std::fs::remove_dir_all(&parent);
+    let dir = parent.join("node_modules");
+    std::fs::create_dir_all(dir.join("nested/node_modules")).unwrap();
+    std::fs::write(dir.join("inside.txt"), PROPOSAL).unwrap();
+    std::fs::write(dir.join("nested/node_modules/LICENSE.md"), "MIT\n").unwrap();
+    let paths = scanned_paths(&scan_json(&dir));
+    assert!(
+        paths.iter().any(|p| p.ends_with("inside.txt")),
+        "walk root named node_modules must still be scanned: {paths:?}"
+    );
+    assert!(
+        paths.iter().all(|p| !p.contains("/nested/node_modules/")),
+        "{paths:?}"
+    );
+    let _ = std::fs::remove_dir_all(&parent);
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -9,6 +9,11 @@ CORPUS="${1:-target/e2e-corpus}"
 cargo build --release -q
 cargo run --release -q -p dupey --example mkfixtures -- "$CORPUS" 1
 
+# Vendor/VCS trees must not be descended into (issue #5).
+mkdir -p "$CORPUS/node_modules/pkg" "$CORPUS/.git"
+printf '%s\n' 'MIT License dummy from vendor' > "$CORPUS/node_modules/pkg/LICENSE.md"
+printf '%s\n' 'should not be scanned' > "$CORPUS/.git/README.md"
+
 ./target/release/dupey scan "$CORPUS" --json > target/e2e-scan.json
 
 python3 - "$CORPUS" <<'PY'
@@ -113,6 +118,12 @@ if scanpdf:
 else:
     err = any(e["path"].endswith("scan.pdf") for e in out["errors"])
     check("scanned pdf surfaces as error", err)
+
+# 13. vendor/VCS trees are not descended into
+all_paths = [f["path"].replace("\\", "/") for f in out["files"]]
+all_paths += [e["path"].replace("\\", "/") for e in out["errors"]]
+check("skips node_modules", all(p.find("/node_modules/") < 0 for p in all_paths))
+check("skips .git", all(p.find("/.git/") < 0 for p in all_paths))
 
 if fails:
     print(f"\n{len(fails)} check(s) failed")


### PR DESCRIPTION
Fixes #5 (walk half).

`dupey scan` was already extension-filtered, but it still walked
`node_modules` / `.git` and then extracted every `LICENSE.md` /
`README.md`. Biggest family on a Downloads dump was 219 MIT licenses.

## Change
- Builtin skip is a **directory name** allow-deny list (case-insensitive, last component only). Children are not walked.
- Scan root is never skipped, so `dupey scan node_modules` still reads that folder.
- `--exclude-dir NAME` is repeatable and merged with the builtins (`임시`, `./백업/` both work).
- Not a gitignore parser.

## Verify
- `cargo test --workspace`
- `./scripts/e2e.sh` — including live `node_modules` / `.git` planted in the corpus