### PR TITLE
core: verify near duplicates with exact Jaccard

### DIFF
--- a/crates/dupey-cli/src/main.rs
+++ b/crates/dupey-cli/src/main.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use dupey_core::{
-    cluster, containment, exact_hash_hex, extract, near_sig, rank, CanonicalText,
-    Format, MemberSignals, ScannedDoc, DEFAULT_NEAR_THRESHOLD,
+    cluster, containment, exact_hash_hex, extract, near_sig, rank, CanonicalText, Format,
+    MemberSignals, ScannedDoc, DEFAULT_NEAR_THRESHOLD,
 };
 use serde::Serialize;
 
@@ -31,7 +31,7 @@ enum Command {
         /// Emit the public JSON contract instead of a human summary
         #[arg(long)]
         json: bool,
-        /// Family threshold for near/contains (Jaccard estimate)
+        /// Exact shingle Jaccard threshold for near/contains
         #[arg(long, default_value_t = DEFAULT_NEAR_THRESHOLD)]
         threshold: f64,
     },
@@ -73,11 +73,19 @@ fn compare(a: &Path, b: &Path) -> Result<()> {
     let cb = extract(b).with_context(|| format!("extract {}", b.display()))?;
     let ha = exact_hash_hex(&ca.text);
     let hb = exact_hash_hex(&cb.text);
+    let sa = dupey_core::shingles(&ca.text);
+    let sb = dupey_core::shingles(&cb.text);
     let near = dupey_core::score(&near_sig(&ca.text), &near_sig(&cb.text));
+    let jaccard = dupey_core::exact_jaccard(&sa, &sb);
+    let a_in_b = containment(&sb, &sa);
+    let b_in_a = containment(&sa, &sb);
     println!("a\t{}", a.display());
     println!("b\t{}", b.display());
     println!("exact_equal\t{}", ha == hb);
     println!("near_score\t{near:.4}");
+    println!("jaccard\t{jaccard:.4}");
+    println!("containment_a_in_b\t{a_in_b:.4}");
+    println!("containment_b_in_a\t{b_in_a:.4}");
     Ok(())
 }
 

--- a/crates/dupey-core/src/family.rs
+++ b/crates/dupey-core/src/family.rs
@@ -1,14 +1,15 @@
 //! Cluster documents into families (exact / near / contains).
 //!
 //! exact groups by SHA-256 of canonical text, near uses LSH over MinHash
-//! signatures at the family threshold (default 0.90), contains uses
+//! candidates and exact shingle Jaccard at the family threshold (default 0.90), contains uses
 //! shingle containment for the draft-inside-final case. Documents with no
 //! comparable text (e.g. scanned PDFs) never cluster.
 
 use std::path::PathBuf;
 
 use crate::near::{
-    containment, containment_at_least, near_sig, score, shingles, NearSignature,
+    containment, containment_at_least, exact_jaccard, near_sig, score, shingles, NearSignature,
+    MINHASH_CANDIDATE_THRESHOLD,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -26,6 +27,8 @@ pub struct FamilyMember {
     pub relation: Relation,
     /// MinHash Jaccard estimate against the family anchor.
     pub near_score: Option<f64>,
+    /// Exact shingle Jaccard against the family anchor, when computed.
+    pub jaccard: Option<f64>,
     /// Shingle containment against the family anchor, when computed.
     pub containment: Option<f64>,
 }
@@ -73,25 +76,21 @@ impl ScannedDoc {
 
 /// Group comparable documents into families of 2+ members.
 ///
-/// LSH runs at a loose candidate threshold (0.5) and every candidate pair
-/// is verified with the exact MinHash estimate, so LSH approximation can
-/// only cost recall, never precision. Contains candidates need the loose
+/// LSH runs at a loose MinHash candidate threshold (0.8), then near pairs
+/// are verified with exact shingle Jaccard. Contains candidates need the
 /// threshold: a draft inside a final can sit at Jaccard 0.5-0.7.
 pub fn cluster(docs: &[ScannedDoc], threshold: f64) -> Vec<Family> {
-    // gaoya requires bands x width == signature length (128). 32x4
-    // keeps template pairs (~0.8 Jaccard) from flooding candidates;
-    // containment recall is covered by the bottom-k sketch index, so
-    // LSH only needs to be reliable at the near threshold.
-    const LSH_BANDS: usize = 32;
-    const LSH_BAND_WIDTH: usize = 4;
-    const LSH_CANDIDATE_THRESHOLD: f64 = 0.5;
-
+    let candidate_threshold = MINHASH_CANDIDATE_THRESHOLD.min(threshold);
+    // gaoya requires bands x width == signature length (128). 16x8
+    // retrieves a MinHash-0.8 pair with ~94.7% probability while
+    // suppressing the much larger population below the candidate gate.
+    const LSH_BANDS: usize = 16;
+    const LSH_BAND_WIDTH: usize = 8;
     let comp: Vec<usize> = (0..docs.len()).filter(|&i| docs[i].comparable()).collect();
     let mut uf = UnionFind::new(docs.len());
 
     // exact: same canonical SHA-256.
-    let mut by_hash: std::collections::HashMap<&str, Vec<usize>> =
-        std::collections::HashMap::new();
+    let mut by_hash: std::collections::HashMap<&str, Vec<usize>> = std::collections::HashMap::new();
     for &i in &comp {
         by_hash.entry(&docs[i].exact_hash).or_default().push(i);
     }
@@ -104,11 +103,8 @@ pub fn cluster(docs: &[ScannedDoc], threshold: f64) -> Vec<Family> {
     // near / contains: candidate generation, every candidate verified.
     // LSH covers near; a bottom-k inverted index covers containment of
     // documents too small for LSH bands to see (draft inside final).
-    let mut index = gaoya::minhash::MinHashIndex::new(
-        LSH_BANDS,
-        LSH_BAND_WIDTH,
-        LSH_CANDIDATE_THRESHOLD,
-    );
+    let mut index =
+        gaoya::minhash::MinHashIndex::new(LSH_BANDS, LSH_BAND_WIDTH, candidate_threshold);
     for &i in &comp {
         index.insert(i, docs[i].sig.values.clone());
     }
@@ -156,7 +152,9 @@ pub fn cluster(docs: &[ScannedDoc], threshold: f64) -> Vec<Family> {
             continue;
         }
         let s = score(&docs[i].sig, &docs[j].sig);
-        if s >= threshold {
+        if s >= candidate_threshold
+            && exact_jaccard(&docs[i].shingles, &docs[j].shingles) >= threshold
+        {
             uf.union(i, j);
             continue;
         }
@@ -193,10 +191,7 @@ pub fn cluster(docs: &[ScannedDoc], threshold: f64) -> Vec<Family> {
     for &i in &comp {
         components.entry(uf.find(i)).or_default().push(i);
     }
-    let mut groups: Vec<Vec<usize>> = components
-        .into_values()
-        .filter(|g| g.len() >= 2)
-        .collect();
+    let mut groups: Vec<Vec<usize>> = components.into_values().filter(|g| g.len() >= 2).collect();
     groups.sort_by_key(|g| g[0]);
 
     groups
@@ -206,7 +201,9 @@ pub fn cluster(docs: &[ScannedDoc], threshold: f64) -> Vec<Family> {
             let anchor = group[0];
             let members = group
                 .iter()
-                .map(|&i| member_against_anchor(docs, i, anchor, threshold))
+                .map(|&i| {
+                    member_against_anchor(docs, i, anchor, threshold, candidate_threshold)
+                })
                 .collect();
             Family {
                 id: id as u32,
@@ -222,6 +219,7 @@ fn member_against_anchor(
     i: usize,
     anchor: usize,
     threshold: f64,
+    candidate_threshold: f64,
 ) -> FamilyMember {
     if i == anchor || docs[i].exact_hash == docs[anchor].exact_hash {
         return FamilyMember {
@@ -229,26 +227,30 @@ fn member_against_anchor(
             exact_hash: docs[i].exact_hash.clone(),
             relation: Relation::Exact,
             near_score: Some(1.0),
+            jaccard: Some(1.0),
             containment: Some(1.0),
         };
     }
     let s = score(&docs[i].sig, &docs[anchor].sig);
+    let jaccard = Some(exact_jaccard(&docs[i].shingles, &docs[anchor].shingles));
     let c_in = containment(&docs[anchor].shingles, &docs[i].shingles);
     let c_out = containment(&docs[i].shingles, &docs[anchor].shingles);
     let c = c_in.max(c_out);
-    let relation = if s >= threshold {
-        Relation::Near
-    } else if c >= threshold {
-        Relation::Contains
-    } else {
-        // Joined transitively through another member.
-        Relation::Near
-    };
+    let relation =
+        if s >= candidate_threshold && jaccard.is_some_and(|value| value >= threshold) {
+            Relation::Near
+        } else if c >= threshold {
+            Relation::Contains
+        } else {
+            // Joined transitively through another member.
+            Relation::Near
+        };
     FamilyMember {
         path: docs[i].path.clone(),
         exact_hash: docs[i].exact_hash.clone(),
         relation,
         near_score: Some(s),
+        jaccard,
         containment: Some(c),
     }
 }
@@ -282,7 +284,7 @@ impl UnionFind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::near::DEFAULT_NEAR_THRESHOLD;
+    use crate::near::{exact_jaccard, score, DEFAULT_NEAR_THRESHOLD, MINHASH_CANDIDATE_THRESHOLD};
 
     fn doc(name: &str, text: &str) -> ScannedDoc {
         ScannedDoc::from_text(PathBuf::from(name), text)
@@ -332,6 +334,67 @@ mod tests {
     }
 
     #[test]
+    fn minhash_candidate_below_final_threshold_uses_exact_jaccard() {
+        let base = (0..240)
+            .map(|i| format!("문서고유문장{i:04}"))
+            .collect::<Vec<_>>();
+        let base_text = base.join(" ");
+        let base_doc = doc("draft.hwp", &base_text);
+        let variant_text = (1..80)
+            .find_map(|changed| {
+                let mut variant = base.clone();
+                for (i, word) in variant.iter_mut().take(changed).enumerate() {
+                    *word = format!("수정문장{i:04}");
+                }
+                let text = variant.join(" ");
+                let candidate = doc("candidate.hwp", &text);
+                let estimate = score(&base_doc.sig, &candidate.sig);
+                let jaccard = exact_jaccard(&base_doc.shingles, &candidate.shingles);
+                (estimate >= MINHASH_CANDIDATE_THRESHOLD
+                    && estimate < DEFAULT_NEAR_THRESHOLD
+                    && jaccard >= DEFAULT_NEAR_THRESHOLD)
+                    .then_some(text)
+            })
+            .expect("fixture should expose a MinHash false negative near the threshold");
+
+        let docs = vec![base_doc, doc("final.hwp", &variant_text)];
+        let families = cluster(&docs, DEFAULT_NEAR_THRESHOLD);
+        assert_eq!(families.len(), 1);
+        let near = families[0]
+            .members
+            .iter()
+            .find(|member| member.path == PathBuf::from("final.hwp"))
+            .unwrap();
+        assert_eq!(near.relation, Relation::Near);
+        assert!(near.near_score.unwrap() < DEFAULT_NEAR_THRESHOLD);
+        assert!(near.jaccard.unwrap() >= DEFAULT_NEAR_THRESHOLD);
+    }
+
+    #[test]
+    fn minhash_candidate_above_final_threshold_needs_exact_jaccard() {
+        let base_text = paragraphs("기준", 30);
+        let extended_text = format!("{base_text}\n{}", paragraphs("부록추가내용", 40));
+        let base_doc = doc("base.hwp", &base_text);
+        let mut candidate = doc("different.hwp", &extended_text);
+        assert!(exact_jaccard(&base_doc.shingles, &candidate.shingles) < DEFAULT_NEAR_THRESHOLD);
+        assert!(containment(&candidate.shingles, &base_doc.shingles) >= DEFAULT_NEAR_THRESHOLD);
+        // Simulate a MinHash overestimate deterministically: final near
+        // judgment must still use the complete shingle sets.
+        candidate.sig = base_doc.sig.clone();
+        let docs = vec![base_doc, candidate];
+        let families = cluster(&docs, DEFAULT_NEAR_THRESHOLD);
+        assert_eq!(families.len(), 1);
+        let member = families[0]
+            .members
+            .iter()
+            .find(|member| member.path == PathBuf::from("different.hwp"))
+            .unwrap();
+        assert_eq!(member.relation, Relation::Contains);
+        assert!(member.near_score.unwrap() >= DEFAULT_NEAR_THRESHOLD);
+        assert!(member.jaccard.unwrap() < DEFAULT_NEAR_THRESHOLD);
+    }
+
+    #[test]
     fn contains_family() {
         let draft = paragraphs("초안", 10);
         // Appendix uses wholly different vocabulary so Jaccard stays well
@@ -345,7 +408,10 @@ mod tests {
         ]
         .join("\n");
         let final_doc = format!("{draft}\n{appendix}");
-        let docs = vec![doc("보고서_초안.docx", &draft), doc("보고서_최종.docx", &final_doc)];
+        let docs = vec![
+            doc("보고서_초안.docx", &draft),
+            doc("보고서_최종.docx", &final_doc),
+        ];
         let fams = cluster(&docs, DEFAULT_NEAR_THRESHOLD);
         assert_eq!(fams.len(), 1, "draft inside final must still be family");
         let contains = fams[0]
@@ -362,7 +428,10 @@ mod tests {
     fn unrelated_docs_form_no_family() {
         let docs = vec![
             doc("a.txt", &proposal()),
-            doc("b.txt", "오늘 점심은 김치찌개다. 오후에는 운동을 하고 책을 읽는다."),
+            doc(
+                "b.txt",
+                "오늘 점심은 김치찌개다. 오후에는 운동을 하고 책을 읽는다.",
+            ),
         ];
         assert!(cluster(&docs, DEFAULT_NEAR_THRESHOLD).is_empty());
     }
@@ -439,5 +508,3 @@ mod tests {
         assert_ne!(fams[0].id, fams[1].id);
     }
 }
-
-

--- a/crates/dupey-core/src/lib.rs
+++ b/crates/dupey-core/src/lib.rs
@@ -15,7 +15,7 @@ pub use exact::{exact_hash, exact_hash_hex};
 pub use extract::{extract, CanonicalText, DocMeta, Format};
 pub use family::{cluster, Family, FamilyMember, Relation, ScannedDoc};
 pub use near::{
-    containment, containment_at_least, near_sig, score, shingles, NearSignature,
-    DEFAULT_NEAR_THRESHOLD, NUM_PERM,
+    containment, containment_at_least, exact_jaccard, near_sig, score, shingles, NearSignature,
+    DEFAULT_NEAR_THRESHOLD, MINHASH_CANDIDATE_THRESHOLD, NUM_PERM,
 };
 pub use rank::{rank, FamilyRanking, MemberSignals, RankSignal, RankedMember};

--- a/crates/dupey-core/src/near.rs
+++ b/crates/dupey-core/src/near.rs
@@ -11,6 +11,8 @@ pub const CHAR_NGRAM: usize = 5;
 
 /// Default Jaccard threshold for treating two docs as one family.
 pub const DEFAULT_NEAR_THRESHOLD: f64 = 0.90;
+/// MinHash estimate required before paying for exact shingle Jaccard.
+pub const MINHASH_CANDIDATE_THRESHOLD: f64 = 0.80;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NearSignature {
@@ -54,6 +56,31 @@ pub fn shingles(text: &str) -> Vec<u64> {
     v
 }
 
+/// Exact Jaccard similarity for sorted, deduplicated shingle hashes.
+pub fn exact_jaccard(a: &[u64], b: &[u64]) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let mut shared = 0usize;
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => {
+                shared += 1;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    let union = a.len() + b.len() - shared;
+    shared as f64 / union as f64
+}
+
 /// |A ∩ B| / |B|: how much of B lives inside A.
 pub fn containment(a: &[u64], b: &[u64]) -> f64 {
     containment_at_least(a, b, 0.0)
@@ -90,10 +117,16 @@ pub fn containment_at_least(a: &[u64], b: &[u64], threshold: f64) -> f64 {
 }
 
 fn char_ngrams(text: &str, n: usize) -> impl Iterator<Item = String> + '_ {
-    let normalized: String = whitespace_split(&text.to_lowercase()).collect::<Vec<_>>().join(" ");
+    let normalized: String = whitespace_split(&text.to_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
     let chars: Vec<char> = normalized.chars().collect();
     let len = chars.len();
-    let take = if len < n { usize::from(len > 0) } else { len - n + 1 };
+    let take = if len < n {
+        usize::from(len > 0)
+    } else {
+        len - n + 1
+    };
     (0..take).map(move |i| {
         let end = (i + n).min(len);
         chars[i..end].iter().collect()
@@ -147,5 +180,12 @@ mod tests {
         let b = "오늘 점심은 김치찌개다. 오후에는 운동을 하고 책을 읽는다.";
         let s = score(&near_sig(&a), &near_sig(b));
         assert!(s < 0.3, "expected unrelated score, got {s}");
+    }
+
+    #[test]
+    fn exact_jaccard_is_computed_from_complete_shingle_sets() {
+        assert!((exact_jaccard(&[1, 2, 3, 4], &[1, 2, 3, 5]) - 0.6).abs() < 1e-9);
+        assert_eq!(exact_jaccard(&[], &[]), 1.0);
+        assert_eq!(exact_jaccard(&[1], &[]), 0.0);
     }
 }


### PR DESCRIPTION
## Summary
- use MinHash >= 0.80 only as the near-duplicate candidate gate
- use exact sorted 5-gram Jaccard >= the configured threshold (default 0.90) as the final near verdict
- tune LSH to 16x8 for high recall around the 0.80 candidate boundary
- retain directional containment as a separate relation
- expose exact Jaccard in `dupey compare` and family-member JSON

## TDD
- regression: exact Jaccard >= 0.90 still clusters when the 128-permutation MinHash estimate is below 0.90 but above 0.80
- regression: a MinHash overestimate cannot promote a pair to `near` when exact Jaccard is below 0.90
- exact Jaccard unit tests cover overlap and empty-set boundaries

## Verification
- `cargo test --workspace` (54 tests passed)
- `cargo build --workspace --release`
- `./scripts/e2e.sh` (all documented checks passed)
- manual CLI QA: compare happy path, unsupported input, and `--help`

## Downloads comparison
Compared all 102 HWP/HWPX files (5,151 pairs) against parent commit `98b9781`:
- 17 pair classifications became more accurate
- 15 MinHash false negatives (`0.8906-0.8984`) with exact Jaccard `0.9047-0.9170` are now correctly `near` rather than only `contains`
- 2 MinHash false positives (`0.9062`) with exact Jaccard about `0.856` are no longer labeled `near`; they remain correctly connected by containment about `0.9405`
- connected families stayed stable: 13 families, 73 documents, largest family 26
- all-pairs diagnostic runtime: 9.58s -> 10.47s (+9.3%); this intentionally computes exact Jaccard for every pair
- real 8-HWP `scan` median: 60.73ms -> 61.36ms (+1.0%), because production scan computes exact Jaccard only for MinHash candidates

## Dependency
Stacked on #7 because the real-corpus comparison requires the rhwp HWP extraction change. Retarget this PR to `main` after #7 merges.