### PR TITLE
fix: allow release prep to package dirty version bump

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -111,7 +111,7 @@ jobs:
           cargo clippy --workspace --all-targets --all-features -- -D warnings
           cargo test --workspace --locked
           cargo build --workspace --release --locked
-          cargo package --locked -p dupey-core
+          cargo package --locked --allow-dirty -p dupey-core
 
       - name: Commit version bump
         env:


### PR DESCRIPTION
## Summary
- allow the prepare-release validation to package after its intentional Cargo.toml version bump
- keep the actual tag-triggered publish workflow strict on a clean commit

## Validation
- actionlint
- cargo package --locked --allow-dirty -p dupey-core
- pre-push cargo fmt, clippy, and test hooks