### PR TITLE
fix: check crates.io for published release versions

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -78,7 +78,7 @@ jobs:
           fi
 
           for package in dupey-core dupey; do
-            if cargo info "${package}@${RELEASE_VERSION}" >/dev/null 2>&1; then
+            if cargo info --registry crates-io "${package}@${RELEASE_VERSION}" >/dev/null 2>&1; then
               echo "${package} ${RELEASE_VERSION} is already published."
               exit 1
             fi


### PR DESCRIPTION
## Summary
- force prepare-release publication checks to query the crates.io registry
- avoid treating the local workspace package as an already-published release

## Validation
- actionlint
- explicit registry checks return unpublished for dupey-core 0.1.1 and dupey 0.1.1
- pre-push format, clippy, and workspace tests