### PR TITLE
fix: configure release tag identity

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -151,6 +151,8 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           tag="v${RELEASE_VERSION}"
           git tag -a "$tag" -m "dupey ${RELEASE_VERSION}"
           git push origin "$tag"


### PR DESCRIPTION
## Summary
- configure the GitHub Actions bot identity before creating the annotated release tag
- fixes Prepare release failing with empty committer identity

## Validation
- actionlint
- annotated tag creation with the configured bot identity
- pre-push format, clippy, and workspace tests