### PR TITLE
fix: detect exact copies of empty documents

### DIFF
--- a/crates/dupey-cli/src/main.rs
+++ b/crates/dupey-cli/src/main.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use dupey_core::{
-    cluster, containment, exact_hash_hex, extract, near_sig, rank, shingles, CanonicalText, Format,
-    MemberSignals, NearSignature, ScannedDoc, DEFAULT_NEAR_THRESHOLD,
+    byte_hash_hex, cluster, containment, exact_hash_hex, extract, near_sig, rank, shingles,
+    CanonicalText, Format, MemberSignals, NearSignature, ScannedDoc, DEFAULT_NEAR_THRESHOLD,
 };
 use serde::Serialize;
 
@@ -151,6 +151,7 @@ struct PreparedScan {
     canon: CanonicalText,
     fs_mtime: Option<jiff::Timestamp>,
     exact_hash: String,
+    byte_hash: Option<String>,
     sig: NearSignature,
     shingles: Vec<u64>,
     chars: usize,
@@ -187,6 +188,16 @@ fn scan(dir: &Path, json: bool, threshold: f64, extra_exclude: &[String]) -> Res
         .par_iter()
         .map(|path| {
             let canon = extract(path)?;
+            let byte_hash = if canon.text.is_empty() {
+                Some(byte_hash_hex(&std::fs::read(path).map_err(|source| {
+                    dupey_core::Error::Io {
+                        path: path.to_path_buf(),
+                        source,
+                    }
+                })?))
+            } else {
+                None
+            };
             let fs_mtime = std::fs::metadata(path)
                 .and_then(|m| m.modified())
                 .ok()
@@ -201,6 +212,7 @@ fn scan(dir: &Path, json: bool, threshold: f64, extra_exclude: &[String]) -> Res
                 canon,
                 fs_mtime,
                 exact_hash,
+                byte_hash,
                 sig,
                 shingles,
                 chars,
@@ -214,15 +226,17 @@ fn scan(dir: &Path, json: bool, threshold: f64, extra_exclude: &[String]) -> Res
                     canon,
                     fs_mtime,
                     exact_hash,
+                    byte_hash,
                     sig,
                     shingles,
                     chars,
                 } = prepared;
                 let fuzzy = (!canon.text.is_empty()).then(|| sig.values.clone());
+                let content_hash = byte_hash.clone().unwrap_or_else(|| exact_hash.clone());
                 files.push(FileEntry {
                     path: canon.path.display().to_string(),
                     format: canon.format,
-                    content_hash: exact_hash.clone(),
+                    content_hash,
                     fuzzy,
                     signals: FileSignals {
                         chars,
@@ -231,12 +245,18 @@ fn scan(dir: &Path, json: bool, threshold: f64, extra_exclude: &[String]) -> Res
                         fs_mtime: fs_mtime.map(|t| t.to_string()),
                     },
                 });
-                docs.push(ScannedDoc::from_precomputed(
-                    canon.path.clone(),
-                    exact_hash,
-                    sig,
-                    shingles,
-                ));
+                docs.push(match byte_hash {
+                    Some(byte_hash) => ScannedDoc::from_precomputed_with_byte_hash(
+                        canon.path.clone(),
+                        byte_hash.clone(),
+                        byte_hash,
+                        sig,
+                        shingles,
+                    ),
+                    None => {
+                        ScannedDoc::from_precomputed(canon.path.clone(), exact_hash, sig, shingles)
+                    }
+                });
                 metas.push((canon, fs_mtime));
             }
             Err(e) => errors.push(ErrorEntry {

--- a/crates/dupey-cli/tests/cli.rs
+++ b/crates/dupey-cli/tests/cli.rs
@@ -100,6 +100,30 @@ fn unsupported_cjk_pdf() -> Vec<u8> {
     pdf.into_bytes()
 }
 
+fn empty_page_pdf() -> Vec<u8> {
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>".to_string(),
+    ];
+    let mut pdf = String::from("%PDF-1.4\n");
+    let mut offsets = Vec::new();
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.push_str(&format!("{} 0 obj\n{}\nendobj\n", i + 1, body));
+    }
+    let xref_at = pdf.len();
+    let n = objects.len() + 1;
+    pdf.push_str(&format!("xref\n0 {n}\n0000000000 65535 f \n"));
+    for off in offsets {
+        pdf.push_str(&format!("{off:010} 00000 n \n"));
+    }
+    pdf.push_str(&format!(
+        "trailer\n<< /Size {n} /Root 1 0 R >>\nstartxref\n{xref_at}\n%%EOF\n"
+    ));
+    pdf.into_bytes()
+}
+
 const PROPOSAL: &str =
     "프로젝트 제안서\n\n1. 배경\n본 제안은 2026년 하반기 사무 자동화 도입을 위한 것이다. \
      현재 팀은 문서가 폴더에 흩어져 있고 최신본을 찾기 어렵다.\n\n2. 범위\n문서 수집, \
@@ -196,6 +220,25 @@ fn scan_exact_duplicate_group() {
     let families = v["families"].as_array().unwrap();
     assert_eq!(families.len(), 1);
     assert_eq!(families[0]["relation"], "exact");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn scan_groups_byte_identical_empty_pdfs() {
+    let dir = fixture_dir("empty-pdf-exact", &[("scan-a.pdf", "")]);
+    std::fs::write(dir.join("scan-a.pdf"), empty_page_pdf()).unwrap();
+    std::fs::copy(dir.join("scan-a.pdf"), dir.join("scan-b.pdf")).unwrap();
+
+    let v = scan_json(&dir);
+    let families = v["families"].as_array().unwrap();
+    assert_eq!(families.len(), 1, "{v}");
+    assert_eq!(families[0]["relation"], "exact");
+    assert_eq!(families[0]["files"].as_array().unwrap().len(), 2);
+    assert!(v["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|file| file["fuzzy"].is_null()));
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/crates/dupey-core/src/exact.rs
+++ b/crates/dupey-core/src/exact.rs
@@ -12,6 +12,19 @@ pub fn exact_hash_hex(text: &str) -> String {
     hex::encode(exact_hash(text))
 }
 
+/// SHA-256 of original file bytes, used for exact matching when extraction
+/// produced no comparable text.
+pub fn byte_hash(bytes: &[u8]) -> [u8; 32] {
+    let digest = Sha256::digest(bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+pub fn byte_hash_hex(bytes: &[u8]) -> String {
+    hex::encode(byte_hash(bytes))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -20,5 +33,11 @@ mod tests {
     fn stable_and_sensitive() {
         assert_eq!(exact_hash("hello"), exact_hash("hello"));
         assert_ne!(exact_hash("hello"), exact_hash("hello "));
+    }
+
+    #[test]
+    fn byte_hash_is_stable_and_sensitive() {
+        assert_eq!(byte_hash_hex(b"hello"), byte_hash_hex(b"hello"));
+        assert_ne!(byte_hash_hex(b"hello"), byte_hash_hex(b"hello "));
     }
 }

--- a/crates/dupey-core/src/family.rs
+++ b/crates/dupey-core/src/family.rs
@@ -3,7 +3,7 @@
 //! exact groups by SHA-256 of canonical text, near uses LSH over MinHash
 //! candidates and exact shingle Jaccard at the family threshold (default 0.90), contains uses
 //! shingle containment for the draft-inside-final case. Documents with no
-//! comparable text (e.g. scanned PDFs) never cluster.
+//! comparable text only cluster when their original bytes are exact matches.
 
 use std::path::PathBuf;
 
@@ -49,6 +49,7 @@ pub const SKETCH_K: usize = 64;
 pub struct ScannedDoc {
     pub path: PathBuf,
     pub exact_hash: String,
+    pub byte_hash: Option<String>,
     pub sig: NearSignature,
     pub shingles: Vec<u64>,
     /// k smallest shingle hashes; inverted index key for containment
@@ -71,10 +72,23 @@ impl ScannedDoc {
         Self {
             path,
             exact_hash,
+            byte_hash: None,
             sig,
             sketch: shingles.iter().take(SKETCH_K).copied().collect(),
             shingles,
         }
+    }
+
+    pub fn from_precomputed_with_byte_hash(
+        path: PathBuf,
+        exact_hash: String,
+        byte_hash: String,
+        sig: NearSignature,
+        shingles: Vec<u64>,
+    ) -> Self {
+        let mut doc = Self::from_precomputed(path, exact_hash, sig, shingles);
+        doc.byte_hash = Some(byte_hash);
+        doc
     }
 
     /// Scanned PDFs and empty files have no comparable content.
@@ -104,6 +118,22 @@ pub fn cluster(docs: &[ScannedDoc], threshold: f64) -> Vec<Family> {
         by_hash.entry(&docs[i].exact_hash).or_default().push(i);
     }
     for group in by_hash.values() {
+        for &i in &group[1..] {
+            uf.union(group[0], i);
+        }
+    }
+    // Empty extraction cannot support fuzzy comparison, but byte-identical
+    // files are still exact duplicates (for example, copied scanned PDFs).
+    let mut by_byte_hash: std::collections::HashMap<&str, Vec<usize>> =
+        std::collections::HashMap::new();
+    for (i, doc) in docs.iter().enumerate() {
+        if !doc.comparable() {
+            if let Some(hash) = doc.byte_hash.as_deref() {
+                by_byte_hash.entry(hash).or_default().push(i);
+            }
+        }
+    }
+    for group in by_byte_hash.values() {
         for &i in &group[1..] {
             uf.union(group[0], i);
         }
@@ -197,8 +227,10 @@ pub fn cluster(docs: &[ScannedDoc], threshold: f64) -> Vec<Family> {
     // Components with 2+ members become families.
     let mut components: std::collections::HashMap<usize, Vec<usize>> =
         std::collections::HashMap::new();
-    for &i in &comp {
-        components.entry(uf.find(i)).or_default().push(i);
+    for (i, doc) in docs.iter().enumerate() {
+        if doc.comparable() || doc.byte_hash.is_some() {
+            components.entry(uf.find(i)).or_default().push(i);
+        }
     }
     let mut groups: Vec<Vec<usize>> = components.into_values().filter(|g| g.len() >= 2).collect();
     groups.sort_by_key(|g| g[0]);
@@ -228,7 +260,11 @@ fn member_against_anchor(
     threshold: f64,
     candidate_threshold: f64,
 ) -> FamilyMember {
-    if i == anchor || docs[i].exact_hash == docs[anchor].exact_hash {
+    let byte_exact = !docs[i].comparable()
+        && !docs[anchor].comparable()
+        && docs[i].byte_hash.is_some()
+        && docs[i].byte_hash == docs[anchor].byte_hash;
+    if i == anchor || docs[i].exact_hash == docs[anchor].exact_hash || byte_exact {
         return FamilyMember {
             path: docs[i].path.clone(),
             exact_hash: docs[i].exact_hash.clone(),
@@ -443,9 +479,51 @@ mod tests {
     }
 
     #[test]
-    fn empty_text_never_clusters() {
-        // Two scanned PDFs: identical (empty) text, but no content to compare.
-        let docs = vec![doc("scan1.pdf", ""), doc("scan2.pdf", "")];
+    fn byte_identical_empty_text_clusters_as_exact() {
+        let empty = near_sig("");
+        let shingles = shingles("");
+        let docs = vec![
+            ScannedDoc::from_precomputed_with_byte_hash(
+                PathBuf::from("scan1.pdf"),
+                crate::exact_hash_hex(""),
+                crate::byte_hash_hex(b"pdf"),
+                empty.clone(),
+                shingles.clone(),
+            ),
+            ScannedDoc::from_precomputed_with_byte_hash(
+                PathBuf::from("scan2.pdf"),
+                crate::exact_hash_hex(""),
+                crate::byte_hash_hex(b"pdf"),
+                empty,
+                shingles,
+            ),
+        ];
+        let fams = cluster(&docs, DEFAULT_NEAR_THRESHOLD);
+        assert_eq!(fams.len(), 1);
+        assert!(fams[0]
+            .members
+            .iter()
+            .all(|member| member.relation == Relation::Exact));
+    }
+
+    #[test]
+    fn byte_different_empty_text_does_not_cluster() {
+        let docs = vec![
+            ScannedDoc::from_precomputed_with_byte_hash(
+                PathBuf::from("scan1.pdf"),
+                crate::exact_hash_hex(""),
+                crate::byte_hash_hex(b"pdf-a"),
+                near_sig(""),
+                shingles(""),
+            ),
+            ScannedDoc::from_precomputed_with_byte_hash(
+                PathBuf::from("scan2.pdf"),
+                crate::exact_hash_hex(""),
+                crate::byte_hash_hex(b"pdf-b"),
+                near_sig(""),
+                shingles(""),
+            ),
+        ];
         assert!(cluster(&docs, DEFAULT_NEAR_THRESHOLD).is_empty());
     }
 

--- a/crates/dupey-core/src/lib.rs
+++ b/crates/dupey-core/src/lib.rs
@@ -11,7 +11,7 @@ pub mod near;
 pub mod rank;
 
 pub use error::{Error, Result};
-pub use exact::{exact_hash, exact_hash_hex};
+pub use exact::{byte_hash, byte_hash_hex, exact_hash, exact_hash_hex};
 pub use extract::{extract, CanonicalText, DocMeta, Format};
 pub use family::{cluster, Family, FamilyMember, Relation, ScannedDoc};
 pub use near::{


### PR DESCRIPTION
## Summary
- hash original bytes only when extraction produces empty text
- group byte-identical empty documents into the existing `exact` relation
- keep fuzzy matching disabled for empty documents and leave byte-different scans ungrouped
- add core and CLI regression coverage for empty PDFs

## Verification
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- manual `dupey scan --json` with two identical empty PDFs and one byte-different empty PDF

Closes #4